### PR TITLE
"words" filter fixes

### DIFF
--- a/fwew.go
+++ b/fwew.go
@@ -441,11 +441,12 @@ func listWordsSubset(args []string, subset []Word) []Word {
 			s, err := strconv.Atoi(spec)
 			if err != nil {
 				fmt.Printf("%s (%s)", Text("invalidNumericError"), spec)
+				return nil
 			}
 			switch cond {
 			case Text("c_first"):
 				if len(subset) >= s {
-					return subset[0 : s-1]
+					return subset[0:s]
 				}
 				return subset
 			case Text("c_last"):
@@ -758,7 +759,7 @@ func listWords(args []string) []Word {
 						results = append(results, result)
 					}
 				case Text("c_last"):
-					if count >= numLines-s && count <= numLines {
+					if count > numLines-s && count <= numLines {
 						result = InitWordStruct(result, fields)
 						results = append(results, result)
 					}

--- a/fwew.go
+++ b/fwew.go
@@ -440,7 +440,7 @@ func listWordsSubset(args []string, subset []Word) []Word {
 		case Text("w_words"):
 			s, err := strconv.Atoi(spec)
 			if err != nil {
-				fmt.Printf("%s (%s)", Text("invalidNumericError"), spec)
+				fmt.Printf("%s (%s)\n", Text("invalidNumericError"), spec)
 				return nil
 			}
 			switch cond {
@@ -750,7 +750,7 @@ func listWords(args []string) []Word {
 				s, err1 := strconv.Atoi(spec)
 				if err1 != nil {
 					fmt.Printf("%s (%s)\n", Text("invalidNumericError"), spec)
-					os.Exit(1)
+					return nil
 				}
 				switch cond {
 				case Text("c_first"):


### PR DESCRIPTION
OBOs:
```
~~> /list words first 2 and word like *
[1] 'ampi vtr. touch

~~> /list words last 2
[1] nävi meme. a common or understandable mistake a beginner to the Na'vi language would make (plural: nävis)
[2] pokx meme. poke
[3] tsyili si meme. to construct a sentence which has a hilariously outlandish meaning, particularly involving shoe-eating ikran
```

Error spam triggered by: `/list words like l*e and syllables = 2`
The first filter is malformed but fwew prints an error for each match of the second filter instead of aborting early.
![](https://cdn.discordapp.com/attachments/403963281502371852/685917370505625621/unknown.png)

`/list words first asd` no longer exits out of interactive sessions